### PR TITLE
Fixed broken build on modern rustc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ simple-error = "0.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 stdweb = "0.4"
+wasm-bindgen = "0.2.69"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.websocket]
 version = "0.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "websocket-client"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Nathan Stoddard"]
 description = "A websocket client library which supports both desktop and webassembly"
 license = "MIT"


### PR DESCRIPTION
Fixes:

* Broken build on modern Rust compiler due to missing `wasm_bindgen` crate
* Removes warnings from using old dynamic trait syntax
* Bumped version